### PR TITLE
feat: migrate to shadCN Sky/Gray theme and refactor main views

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,23 @@
+
+> taskweave@0.0.0 dev
+> next dev -p 4246
+
+ ⨯ Failed to start server
+Error: listen EADDRINUSE: address already in use :::4246
+    at Server.setupListenHandle [as _listen2] (node:net:1940:16)
+    at listenInCluster (node:net:1997:12)
+    at Server.listen (node:net:2102:7)
+    at /app/node_modules/next/dist/server/lib/start-server.js:280:16
+    at new Promise (<anonymous>)
+    at startServer (/app/node_modules/next/dist/server/lib/start-server.js:191:11)
+    at /app/node_modules/next/dist/server/lib/start-server.js:310:52
+    at Span.traceAsyncFn (/app/node_modules/next/dist/trace/trace.js:154:26)
+    at process.<anonymous> (/app/node_modules/next/dist/server/lib/start-server.js:310:35)
+    at process.emit (node:events:519:28) {
+  code: 'EADDRINUSE',
+  errno: -98,
+  syscall: 'listen',
+  address: '::',
+  port: 4246
+}
+[?25h

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -59,7 +59,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       {/* Mobile Overlay */}
       {isMobileMenuOpen && (
         <div 
-            className="fixed inset-0 bg-background/60 z-40 backdrop-blur-sm md:hidden"
+            className="fixed inset-0 bg-black/40 z-40 backdrop-blur-sm md:hidden animate-in fade-in duration-300"
             onClick={() => setIsMobileMenuOpen(false)}
         ></div>
       )}
@@ -67,7 +67,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       {/* Mobile Sidebar (Drawer) */}
       <aside 
         className={`
-            fixed inset-y-0 left-0 z-50 w-sidebar-mobile bg-surface-highlight border-r border-border transform transition-transform duration-300 ease-productive-in-out
+            fixed inset-y-0 left-0 z-50 w-sidebar-mobile bg-card border-r border-border transform transition-transform duration-300 ease-productive-in-out
             ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
       >
@@ -77,7 +77,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       {/* Desktop Sidebar */}
       <aside 
         className={`
-            hidden md:flex flex-col border-r border-border bg-surface transition-all duration-300 ease-productive-in-out
+            hidden md:flex flex-col border-r border-border bg-card transition-all duration-300 ease-productive-in-out
             ${isSidebarOpen ? 'w-sidebar opacity-100' : 'w-0 opacity-0 overflow-hidden'}
         `}
       >
@@ -88,11 +88,11 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       <div className="flex-1 flex flex-col h-full min-w-0 bg-background relative transition-all duration-300">
         
         {/* Responsive Header */}
-        <header className="h-12 flex items-center justify-between px-4 border-b border-border bg-background shrink-0">
+        <header className="h-12 flex items-center justify-between px-4 border-b border-border bg-card shrink-0">
             <div className="flex items-center gap-3">
                 <button 
                     onClick={() => setIsSidebarOpen(!isSidebarOpen)} 
-                    className="hidden md:flex text-secondary hover:text-foreground p-1 rounded hover:bg-foreground/5 transition-colors"
+                    className="hidden md:flex text-muted-foreground hover:text-foreground p-1 rounded-sm hover:bg-accent transition-colors"
                     title={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
                 >
                     {isSidebarOpen ? <PanelLeftClose size={20} /> : <PanelLeftOpen size={20} />}
@@ -100,12 +100,12 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
                 <button 
                     onClick={() => setIsMobileMenuOpen(true)} 
-                    className="md:hidden text-secondary hover:text-foreground"
+                    className="md:hidden text-muted-foreground hover:text-foreground"
                 >
                     <Menu size={20} />
                 </button>
 
-                <button onClick={showDashboard} className="hover:bg-foreground/5 px-2 py-1 rounded transition-colors">
+                <button onClick={showDashboard} className="hover:bg-accent px-2 py-1 rounded-sm transition-colors">
                      <span className="font-semibold text-foreground tracking-tight">Taskweave</span>
                 </button>
             </div>
@@ -132,7 +132,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         {!activeTaskId && (
             <button 
                 onClick={() => quickAddTask()}
-                className="md:hidden fixed bottom-6 right-6 h-14 w-14 rounded-full bg-primary text-background shadow-lg shadow-primary/30 flex items-center justify-center z-40 active:scale-95 transition-transform"
+                className="md:hidden fixed bottom-6 right-6 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 flex items-center justify-center z-40 active:scale-95 transition-transform"
             >
                 <Plus size={28} />
             </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,18 +44,18 @@ export const Sidebar: React.FC = () => {
     /**
      * Internal sub-component for rendering a single navigation link.
      */
-    const NavItem = ({ onClick, icon: Icon, label, isActive, count, colorClass = "text-secondary" }: { onClick: () => void, icon: LucideIcon, label: string, isActive: boolean, count?: number, colorClass?: string }) => {
+    const NavItem = ({ onClick, icon: Icon, label, isActive, count, colorClass = "text-muted-foreground" }: { onClick: () => void, icon: LucideIcon, label: string, isActive: boolean, count?: number, colorClass?: string }) => {
         return (
           <button 
             onClick={onClick}
-            className={`w-full flex items-center justify-between px-2 py-1.5 rounded-md transition-all mb-0.5 group ${isActive ? 'bg-foreground/10 text-foreground' : 'text-secondary hover:bg-foreground/5 hover:text-foreground'}`}
+            className={`w-full flex items-center justify-between px-2 py-1.5 rounded-sm transition-all mb-0.5 group ${isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground'}`}
           >
             <div className="flex items-center gap-2.5">
-              <Icon size={18} className={isActive ? colorClass : 'text-secondary group-hover:text-foreground transition-colors'} />
+              <Icon size={18} className={isActive ? colorClass : 'text-muted-foreground group-hover:text-accent-foreground transition-colors'} />
               <span className={`text-sm ${isActive ? 'font-medium' : 'font-normal'}`}>{label}</span>
             </div>
             {count !== undefined && count > 0 && (
-              <span className="text-xs text-secondary/40 font-medium group-hover:text-secondary/80">{count}</span>
+              <span className="text-xs text-muted-foreground/40 font-medium group-hover:text-muted-foreground/80">{count}</span>
             )}
           </button>
         );
@@ -66,21 +66,21 @@ export const Sidebar: React.FC = () => {
             {/* User Profile Area */}
             <div className="px-3 mb-4 flex items-center justify-between">
                 <div 
-                    className="flex items-center gap-2 cursor-pointer hover:bg-foreground/5 p-1.5 -ml-1.5 rounded-lg transition-colors flex-1"
+                    className="flex items-center gap-2 cursor-pointer hover:bg-accent/50 p-1.5 -ml-1.5 rounded-sm transition-colors flex-1"
                     onClick={showSettings}
                 >
                     <div className="h-6 w-6 rounded-full border border-border overflow-hidden">
                         <img src={settings.photoURL || `https://picsum.photos/seed/${seed}/100`} className="h-full w-full object-cover opacity-80" alt="User avatar" />
                     </div>
                     <span className="text-sm font-semibold text-foreground truncate max-w-32">{settings.displayName}</span>
-                    <ChevronDown size={12} className="text-secondary" />
+                    <ChevronDown size={12} className="text-muted-foreground" />
                 </div>
             </div>
 
             {/* Mobile Quick Add */}
             <div className="px-3 mb-4 md:hidden">
                 <button onClick={() => quickAddTask()} className="w-full flex items-center gap-2 text-primary font-bold py-2">
-                    <div className="w-6 h-6 rounded-full bg-primary text-black flex items-center justify-center">
+                    <div className="w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center">
                         <Plus size={16} />
                     </div>
                     <span>Add Task</span>
@@ -119,11 +119,11 @@ export const Sidebar: React.FC = () => {
 
             {/* Project Tree Section */}
             <div className="mt-4 px-2 flex-1 overflow-hidden flex flex-col min-h-0">
-                <div className="flex items-center justify-between px-2 mb-2 text-secondary group">
+                <div className="flex items-center justify-between px-2 mb-2 text-muted-foreground group">
                     <span className="text-xs font-bold uppercase tracking-wider group-hover:text-foreground transition-colors">Projects</span>
                     <button 
                         onClick={handleAddProject}
-                        className="opacity-0 group-hover:opacity-100 hover:bg-foreground/10 p-1 rounded transition-all text-foreground"
+                        className="opacity-0 group-hover:opacity-100 hover:bg-accent p-1 rounded-sm transition-all text-accent-foreground"
                     >
                         <Plus size={14} />
                     </button>

--- a/src/components/TagSidebar.tsx
+++ b/src/components/TagSidebar.tsx
@@ -102,8 +102,8 @@ export const TagTree: React.FC<TagTreeProps> = ({ tags, tasks, activeTagId, onSe
           <div key={tag.id} className="pl-3">
              <div 
                 className={`
-                    group flex items-center gap-2 py-1.5 pr-2 rounded-lg cursor-pointer transition-colors relative select-none
-                    ${isActive ? 'bg-primary/10 text-primary' : 'text-secondary hover:text-foreground hover:bg-foreground/5'}
+                    group flex items-center gap-2 py-1.5 pr-2 rounded-sm cursor-pointer transition-colors relative select-none
+                    ${isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/50'}
                     ${draggedTagId === tag.id ? 'opacity-50' : 'opacity-100'}
                 `}
                 onClick={() => onSelectTag(tag.id)}
@@ -114,7 +114,7 @@ export const TagTree: React.FC<TagTreeProps> = ({ tags, tasks, activeTagId, onSe
              >
                 <button 
                     onClick={(e) => toggleExpand(tag.id, e)}
-                    className={`p-0.5 rounded hover:bg-foreground/10 ${hasChildren ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+                    className={`p-0.5 rounded-sm hover:bg-accent/50 ${hasChildren ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
                 >
                     {isExpanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
                 </button>
@@ -135,7 +135,7 @@ export const TagTree: React.FC<TagTreeProps> = ({ tags, tasks, activeTagId, onSe
                               triggerElRef.current = e.currentTarget;
                           }
                         }}
-                        className="p-1 rounded hover:bg-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="p-1 rounded-sm hover:bg-accent opacity-0 group-hover:opacity-100 transition-opacity"
                     >
                         <Edit2 size={12} />
                     </button>
@@ -156,7 +156,7 @@ export const TagTree: React.FC<TagTreeProps> = ({ tags, tasks, activeTagId, onSe
     <div className={`overflow-y-auto no-scrollbar ${className}`}>
         {/* Root Drop Zone: Allows dragging tags back to the top level */}
         <div 
-            className="mb-1 px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-secondary/30 border-2 border-dashed border-transparent hover:border-border rounded-lg transition-colors"
+            className="mb-1 px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/30 border-2 border-dashed border-transparent hover:border-border rounded-sm transition-colors"
             onDragOver={handleDragOver}
             onDrop={(e) => handleDrop(e, null)}
         >

--- a/src/components/dashboard/ReadinessRing.tsx
+++ b/src/components/dashboard/ReadinessRing.tsx
@@ -13,13 +13,13 @@ export const ReadinessRing = ({ score }: { score: number }) => {
   const strokeDashoffset = circumference - (score / 100) * circumference;
 
   let colorClass = 'text-primary';
-  if (score < 40) colorClass = 'text-red-400';
-  else if (score < 70) colorClass = 'text-yellow-400';
+  if (score < 40) colorClass = 'text-destructive';
+  else if (score < 70) colorClass = 'text-orange-500';
 
   return (
     <div className="relative w-12 h-12 flex items-center justify-center">
         <svg className="w-full h-full -rotate-90 transform" viewBox="0 0 44 44">
-            <circle cx="22" cy="22" r={radius} className="text-white/5" stroke="currentColor" strokeWidth="4" fill="transparent" />
+            <circle cx="22" cy="22" r={radius} className="text-muted/50" stroke="currentColor" strokeWidth="4" fill="transparent" />
             <circle
                 cx="22" cy="22" r={radius}
                 className={`transition-all duration-1000 ease-out ${colorClass}`}

--- a/src/components/dashboard/SmileyScale.tsx
+++ b/src/components/dashboard/SmileyScale.tsx
@@ -19,10 +19,10 @@ interface SmileyScaleProps {
  */
 export const SmileyScale = ({ value, onChange }: SmileyScaleProps) => {
   const steps = [
-    { level: 1, icon: Angry, color: 'text-red-400', label: 'Drained' },
-    { level: 2, icon: Frown, color: 'text-orange-400', label: 'Low' },
-    { level: 3, icon: Meh, color: 'text-yellow-400', label: 'Neutral' },
-    { level: 4, icon: Smile, color: 'text-emerald-400', label: 'Good' },
+    { level: 1, icon: Angry, color: 'text-destructive', label: 'Drained' },
+    { level: 2, icon: Frown, color: 'text-orange-500', label: 'Low' },
+    { level: 3, icon: Meh, color: 'text-yellow-500', label: 'Neutral' },
+    { level: 4, icon: Smile, color: 'text-emerald-500', label: 'Good' },
     { level: 5, icon: Laugh, color: 'text-primary', label: 'Great' },
   ];
 
@@ -37,7 +37,7 @@ export const SmileyScale = ({ value, onChange }: SmileyScaleProps) => {
             onClick={() => onChange(step.level)}
             className={`group flex flex-col items-center gap-1 transition-all duration-300 outline-none ${isActive ? 'scale-110' : 'opacity-40 hover:opacity-80'}`}
           >
-            <Icon size={24} className={`transition-colors duration-300 ${isActive ? step.color : 'text-secondary'}`} />
+            <Icon size={24} className={`transition-colors duration-300 ${isActive ? step.color : 'text-muted-foreground'}`} />
           </button>
         );
       })}

--- a/src/entities/task/ui/TaskRow.tsx
+++ b/src/entities/task/ui/TaskRow.tsx
@@ -265,11 +265,11 @@ const TaskRowComponent: React.FC<TaskRowProps> = ({
                 ${isBlocked && !isEditing ? 'opacity-50' : ''}
                 ${(isCompleted || isArchived) && !isSelectionMode ? 'cursor-default' : 'cursor-pointer'}
                 ${isCompleting ? 'opacity-0' : ''}
-                ${highlight ? 'bg-primary/5' : (isCheckedForDisplay && isSelectionMode) ? 'bg-surface-highlight' : ''}
-                ${(isCompleted || isArchived || isEditing || (isCheckedForDisplay && isSelectionMode)) ? '' : 'hover:bg-foreground/5'}
+                ${highlight ? 'bg-primary/5' : (isCheckedForDisplay && isSelectionMode) ? 'bg-accent/50' : ''}
+                ${(isCompleted || isArchived || isEditing || (isCheckedForDisplay && isSelectionMode)) ? '' : 'hover:bg-muted/50'}
                 ${isCompleted ? 'opacity-60 hover:opacity-100' : ''}
-                ${isEditing ? 'bg-foreground/[0.08] shadow-xl z-10 px-4 py-4 border-transparent ring-1 ring-border rounded-2xl' : 'px-3'}
-                ${showActions ? 'bg-foreground/5' : ''}
+                ${isEditing ? 'bg-card shadow-xl z-10 px-4 py-4 border-transparent ring-1 ring-border rounded-sm' : 'px-3'}
+                ${showActions ? 'bg-muted/50' : ''}
             `}
             onClick={handleRowClick}
         >
@@ -296,22 +296,22 @@ const TaskRowComponent: React.FC<TaskRowProps> = ({
                     }
                 }}
                 disabled={isBlocked && !isArchived}
-                className={`mt-0.5 w-6 h-6 rounded-full border shrink-0 flex items-center justify-center transition-all duration-200 group/check
+                className={`mt-0.5 w-6 h-6 rounded-sm border shrink-0 flex items-center justify-center transition-all duration-200 group/check
                     ${isBlocked && !isArchived
-                        ? 'border-secondary/20 bg-transparent'
+                        ? 'border-muted-foreground/20 bg-transparent'
                         : isArchived 
                             ? isDeletePending
-                                ? 'bg-red-500 border-red-500 text-white' 
-                                : 'border-red-500/40 text-red-500 hover:bg-red-500/10 hover:border-red-500' 
+                                ? 'bg-destructive border-destructive text-destructive-foreground'
+                                : 'border-destructive/40 text-destructive hover:bg-destructive/10 hover:border-destructive'
                             : isCheckedForDisplay
                                 ? 'bg-primary border-primary text-primary-foreground' 
-                                : (highlight ? 'border-primary hover:bg-primary/20' : 'border-secondary/40 hover:border-primary')
+                                : (highlight ? 'border-primary hover:bg-primary/20' : 'border-input hover:border-primary')
                     }
                 `}
             >
                 {isBlocked && !isArchived ? (
                     <div title={`Blocked by: ${activeBlockers.map(b => b?.title).join(', ')}`}>
-                        <Lock size={10} className="text-secondary/50" />
+                        <Lock size={10} className="text-muted-foreground/50" />
                     </div>
                 ) : isArchived && !isSelectionMode ? (
                     <Trash2 size={isDeletePending ? 12 : 10} className={`${isDeletePending ? 'opacity-100' : 'opacity-70 group-hover/check:opacity-100'}`} />

--- a/src/entities/task/ui/TaskSection.tsx
+++ b/src/entities/task/ui/TaskSection.tsx
@@ -134,12 +134,12 @@ export const TaskSection: React.FC<TaskSectionProps> = ({
         className="flex items-center gap-2 py-2 group cursor-pointer select-none"
         onClick={onToggle}
       >
-        <ChevronRight size={14} className={`text-secondary transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`} />
+        <ChevronRight size={14} className={`text-muted-foreground transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`} />
         <div className="flex-1 flex justify-between items-center">
-            <h2 className={`text-xs font-bold uppercase tracking-widest text-secondary ${colorClass}`}>
+            <h2 className={`text-[10px] font-bold uppercase tracking-widest text-muted-foreground ${colorClass}`}>
                 {title}
             </h2>
-            <span className="text-xs text-secondary/40 font-medium">{displayCount}</span>
+            <span className="text-[10px] text-muted-foreground/40 font-medium">{displayCount}</span>
         </div>
       </div>
       {isExpanded && (
@@ -161,9 +161,9 @@ export const TaskSection: React.FC<TaskSectionProps> = ({
           ) : isCreatable && tasks.length < 15 ? (
             <button
               onClick={onStartAdding}
-              className="flex items-center gap-2 text-xs text-secondary hover:text-primary mb-2 py-1 px-2 hover:bg-foreground/5 rounded transition-colors group"
+              className="flex items-center gap-2 text-[11px] text-muted-foreground hover:text-primary mb-2 py-1 px-2 hover:bg-accent rounded-sm transition-colors group"
             >
-              <div className="p-0.5 rounded-full bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors group-hover:scale-110 transition-transform">
+              <div className="p-0.5 rounded-sm bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors group-hover:scale-110 transition-transform">
                 <Plus size={10} />
               </div>
               <span className="font-bold">
@@ -173,7 +173,7 @@ export const TaskSection: React.FC<TaskSectionProps> = ({
           ) : null}
 
           {/* Task List */}
-          <div className={sectionKey === 'overdue' ? 'border-l border-red-500/20' : ''}>
+          <div className={sectionKey === 'overdue' ? 'border-l border-destructive/20' : ''}>
             {tasks.map((task) => (
               <TaskRow
                 key={task.id}

--- a/src/entities/task/ui/task-row/Chip.tsx
+++ b/src/entities/task/ui/task-row/Chip.tsx
@@ -14,7 +14,7 @@ const chipVariants = cva(
     variants: {
       isActive: {
         true: '',
-        false: 'bg-foreground/5 border-transparent text-secondary hover:bg-foreground/10 hover:text-foreground',
+    false: 'bg-muted/50 border-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
       },
     },
     defaultVariants: {
@@ -84,7 +84,7 @@ export const Chip: React.FC<ChipProps> = ({
   if (!isEditing) {
     if (!isActive && !label) return null;
     return (
-      <div className={`flex items-center gap-1 text-xs transition-colors ${className} ${colorClass} ${isActive ? 'font-medium' : 'opacity-70'}`}>
+      <div className={`flex items-center gap-1 text-[10px] transition-colors ${className} ${colorClass} ${isActive ? 'font-medium' : 'text-muted-foreground/70'}`}>
         {Icon && <Icon size={10} className={fill && isActive ? 'fill-current' : ''} style={iconColor ? { color: iconColor } : {}} />}
         <span style={labelColor ? { color: labelColor } : {}}>{label}</span>
       </div>

--- a/src/entities/task/ui/task-row/TaskDisplay.tsx
+++ b/src/entities/task/ui/task-row/TaskDisplay.tsx
@@ -21,11 +21,11 @@ interface TaskDisplayProps {
 export const TaskDisplay: React.FC<TaskDisplayProps> = ({ title, notes, isCompleted }) => {
     return (
         <>
-            <span className={`text-sm font-medium leading-snug break-words ${isCompleted ? 'line-through text-secondary' : 'text-foreground'}`}>
+            <span className={`text-sm font-medium leading-snug break-words ${isCompleted ? 'line-through text-muted-foreground/60' : 'text-foreground'}`}>
                 {title}
             </span>
             {notes && (
-                <p className="text-xs truncate mt-0.5 text-secondary/60">
+                <p className="text-[11px] truncate mt-0.5 text-muted-foreground">
                     {notes}
                 </p>
             )}

--- a/src/entities/task/ui/task-row/TaskRowActions.tsx
+++ b/src/entities/task/ui/task-row/TaskRowActions.tsx
@@ -67,7 +67,7 @@ export const TaskRowActions: React.FC<TaskRowActionsProps> = ({
         <TooltipProvider>
             <div
                 className={`
-                    absolute right-2 top-2 flex items-center gap-1 p-1 rounded-lg bg-background border border-border shadow-lg z-20
+                    absolute right-2 top-2 flex items-center gap-1 p-1 rounded-sm bg-card border border-border shadow-lg z-20
                     transition-all duration-200
                     ${(showActions || isEditing)
                         ? 'opacity-100 translate-y-0 pointer-events-auto'

--- a/src/entities/task/ui/task-row/TaskRowPickers.tsx
+++ b/src/entities/task/ui/task-row/TaskRowPickers.tsx
@@ -107,11 +107,11 @@ export const TaskRowPickers: React.FC<TaskRowPickersProps> = ({
 
     const getEnergyColor = (lvl: EnergyLevel) => {
         switch(lvl) {
-            case 'Low': return { text: 'text-emerald-400', bg: 'bg-emerald-400/10', border: 'border-emerald-400/20' };
-            case 'High': return { text: 'text-orange-400', bg: 'bg-orange-400/10', border: 'border-orange-400/20' };
+            case 'Low': return { text: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20' };
+            case 'High': return { text: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/20' };
             case 'Medium': 
             default:
-                return { text: 'text-yellow-400', bg: 'bg-yellow-400/10', border: 'border-yellow-400/20' };
+                return { text: 'text-yellow-500', bg: 'bg-yellow-500/10', border: 'border-yellow-500/20' };
         }
     };
     const energyStyle = getEnergyColor(effectiveEnergy);
@@ -161,9 +161,9 @@ export const TaskRowPickers: React.FC<TaskRowPickersProps> = ({
                     label={effectiveDueDate ? new Date(effectiveDueDate).toLocaleDateString(undefined, {month:'short', day:'numeric'}) : "Deadline"}
                     isEditing={isEditing}
                     isActive={!!effectiveDueDate}
-                    colorClass={isOverdue ? "text-red-400 font-bold" : "text-secondary"}
-                    bgClass="bg-red-500/10"
-                    borderClass="border-red-500/20"
+                    colorClass={isOverdue ? "text-destructive font-bold" : "text-muted-foreground"}
+                    bgClass="bg-destructive/10"
+                    borderClass="border-destructive/20"
                     flyoutContent={(close) => <DatePicker value={effectiveDueDate} onChange={(d) => { onDueDateChange(d); close(); }} type="due" />}
                 />
             )}
@@ -223,7 +223,7 @@ export const TaskRowPickers: React.FC<TaskRowPickersProps> = ({
                     label={dependencyCount > 0 ? `${dependencyCount} blocked` : "Blocks"}
                     isEditing={isEditing}
                     isActive={dependencyCount > 0}
-                    colorClass={dependencyCount > 0 ? "text-blue-400" : "text-secondary"}
+                    colorClass={dependencyCount > 0 ? "text-blue-500" : "text-muted-foreground"}
                     bgClass="bg-blue-500/10"
                     borderClass="border-blue-500/20"
                     flyoutContent={(close) => 
@@ -240,7 +240,7 @@ export const TaskRowPickers: React.FC<TaskRowPickersProps> = ({
             {/* Inverse Dependency Status */}
             {!isEditing && tasksBeingBlocked.length > 0 && (
                 <div 
-                    className="flex items-center gap-1 text-[11px] text-blue-400 font-medium"
+                    className="flex items-center gap-1 text-[10px] text-blue-500 font-medium"
                     title={`Blocking ${tasksBeingBlocked.length} task${tasksBeingBlocked.length > 1 ? 's' : ''}: ${tasksBeingBlocked.map(t => t.title).join(', ')}`}
                 >
                     <Share2 size={10} />

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -37,11 +37,11 @@ const DashboardSidebarContent = () => {
     return (
         <>
             {/* Readiness Widget */}
-            <Card className="flex flex-row items-center gap-4 p-4 bg-surface-highlight">
+            <Card className="flex flex-row items-center gap-4 p-4 shadow-none rounded-sm">
                 <ReadinessRing score={state.latestEnergy} />
                 <div>
-                    <span className="text-xs font-bold uppercase tracking-wider text-secondary">Readiness</span>
-                    <p className="text-foreground text-sm leading-tight">
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Readiness</span>
+                    <p className="text-foreground text-sm leading-tight font-medium">
                         {state.latestEnergy > 70 ? "Peak Condition" : state.latestEnergy > 40 ? "Steady State" : "Recovery Needed"}
                     </p>
                 </div>
@@ -49,31 +49,31 @@ const DashboardSidebarContent = () => {
 
             {/* Mood Tracker */}
             <div>
-                <Heading variant="section">Energy Check-in</Heading>
-                <Card className="p-4 bg-foreground/5">
+                <Heading variant="section" className="text-muted-foreground">Energy Check-in</Heading>
+                <Card className="p-4 shadow-none rounded-sm">
                     <SmileyScale value={moodLevel} onChange={handleMoodChange} />
                 </Card>
             </div>
 
             {/* Quick Actions Grid */}
             <div>
-                <Heading variant="section">Quick Actions</Heading>
+                <Heading variant="section" className="text-muted-foreground">Quick Actions</Heading>
                 <div className="grid grid-cols-2 gap-3">
-                    <button onClick={startBreathing} className="p-3 bg-foreground/5 hover:bg-foreground/10 rounded-xl border border-border flex flex-col items-center gap-2 transition-colors">
-                        <Wind size={20} className="text-blue-300" />
-                        <span className="text-xxs font-bold uppercase text-secondary">Breathe</span>
+                    <button onClick={startBreathing} className="p-3 bg-muted/50 hover:bg-accent hover:text-accent-foreground rounded-sm border border-border flex flex-col items-center gap-2 transition-colors">
+                        <Wind size={20} className="text-primary" />
+                        <span className="text-[10px] font-bold uppercase text-muted-foreground group-hover:text-inherit">Breathe</span>
                     </button>
-                    <button onClick={startGrounding} className="p-3 bg-foreground/5 hover:bg-foreground/10 rounded-xl border border-border flex flex-col items-center gap-2 transition-colors">
-                        <Eye size={20} className="text-emerald-300" />
-                        <span className="text-xxs font-bold uppercase text-secondary">Ground</span>
+                    <button onClick={startGrounding} className="p-3 bg-muted/50 hover:bg-accent hover:text-accent-foreground rounded-sm border border-border flex flex-col items-center gap-2 transition-colors">
+                        <Eye size={20} className="text-primary" />
+                        <span className="text-[10px] font-bold uppercase text-muted-foreground group-hover:text-inherit">Ground</span>
                     </button>
-                    <button onClick={showChat} className="p-3 bg-foreground/5 hover:bg-foreground/10 rounded-xl border border-border flex flex-col items-center gap-2 transition-colors">
-                        <MessageSquare size={20} className="text-purple-300" />
-                        <span className="text-xxs font-bold uppercase text-secondary">Journal</span>
+                    <button onClick={showChat} className="p-3 bg-muted/50 hover:bg-accent hover:text-accent-foreground rounded-sm border border-border flex flex-col items-center gap-2 transition-colors">
+                        <MessageSquare size={20} className="text-primary" />
+                        <span className="text-[10px] font-bold uppercase text-muted-foreground group-hover:text-inherit">Journal</span>
                     </button>
-                    <button onClick={() => focusOnTask('')} className="p-3 bg-foreground/5 hover:bg-foreground/10 rounded-xl border border-border flex flex-col items-center gap-2 transition-colors">
+                    <button onClick={() => focusOnTask('')} className="p-3 bg-muted/50 hover:bg-accent hover:text-accent-foreground rounded-sm border border-border flex flex-col items-center gap-2 transition-colors">
                         <Target size={20} className="text-primary" />
-                        <span className="text-xxs font-bold uppercase text-secondary">Focus</span>
+                        <span className="text-[10px] font-bold uppercase text-muted-foreground group-hover:text-inherit">Focus</span>
                     </button>
                 </div>
             </div>
@@ -156,7 +156,7 @@ export const DashboardView: React.FC = () => {
         {/* === LEFT COLUMN / MAIN CONTENT === */}
         <Page.Root className="flex-1 md:border-r md:border-border">
             <Page.Header 
-                title="Focus for today" 
+                title="Today"
                 subtitle={dateStr}
             />
 
@@ -165,11 +165,11 @@ export const DashboardView: React.FC = () => {
                     
                     {/* Intention Input */}
                     <div className="mb-8 group relative">
-                        <div className="absolute left-0 top-1/2 -translate-y-1/2 text-secondary/30 group-focus-within:text-primary transition-colors">
+                        <div className="absolute left-0 top-1/2 -translate-y-1/2 text-muted-foreground/30 group-focus-within:text-primary transition-colors">
                             <Star size={16} fill="currentColor" />
                         </div>
                         <input 
-                            className="w-full bg-transparent border-b border-border py-2 pl-7 text-foreground placeholder:text-secondary/30 focus:outline-none focus:border-primary/50 transition-all text-sm font-medium"
+                            className="w-full bg-transparent border-b border-border py-2 pl-7 text-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:border-primary/50 transition-all text-sm font-medium"
                             placeholder="What is your main focus?"
                             value={intention}
                             onChange={(e) => setIntention(e.target.value)}
@@ -231,12 +231,12 @@ export const DashboardView: React.FC = () => {
                     {/* Quick Add Placeholder */}
                     <button 
                         onClick={() => quickAddTask()}
-                        className="w-full py-3 rounded-lg border border-border hover:bg-foreground/5 text-secondary hover:text-foreground transition-all flex items-center gap-2 px-3 group"
+                        className="w-full py-3 rounded-sm border border-border hover:bg-accent text-muted-foreground hover:text-accent-foreground transition-all flex items-center gap-2 px-3 group"
                     >
-                        <div className="h-5 w-5 rounded-full bg-primary/10 text-primary flex items-center justify-center group-hover:scale-110 transition-transform">
+                        <div className="h-5 w-5 rounded-sm bg-primary/10 text-primary flex items-center justify-center group-hover:scale-110 transition-transform">
                             <Plus size={14} />
                         </div>
-                        <span className="text-sm font-medium">Add task to Flow</span>
+                        <span className="text-sm font-medium">Add task</span>
                     </button>
 
                     {/* Mobile-only sidebar content */}
@@ -248,7 +248,7 @@ export const DashboardView: React.FC = () => {
         </Page.Root>
 
         {/* === RIGHT COLUMN: Context Sidebar (Desktop) === */}
-        <aside className="hidden md:flex w-80 bg-surface flex-col p-6 gap-6 overflow-y-auto no-scrollbar">
+        <aside className="hidden md:flex w-80 bg-muted/30 border-l border-border flex-col p-6 gap-6 overflow-y-auto no-scrollbar">
             <DashboardSidebarContent />
         </aside>
 

--- a/src/views/TaskDatabaseView.tsx
+++ b/src/views/TaskDatabaseView.tsx
@@ -177,7 +177,7 @@ export const TaskDatabaseView: React.FC = () => {
           title={activeTagId ? tags.find(t=>t.id === activeTagId)?.name || 'Inbox' : 'Inbox'} 
           subtitle={activeTagId ? "Project" : undefined}
           actions={
-            <button className="p-2 hover:bg-foreground/5 rounded text-secondary hover:text-foreground transition-colors">
+            <button className="p-2 hover:bg-accent rounded-sm text-muted-foreground hover:text-foreground transition-colors">
                <SlidersHorizontal size={18} />
             </button>
           }
@@ -185,11 +185,11 @@ export const TaskDatabaseView: React.FC = () => {
 
        <Page.Content>
             <div className="mb-4 group relative">
-                <div className="absolute left-0 top-1/2 -translate-y-1/2 text-secondary/30 group-focus-within:text-primary transition-colors">
+                <div className="absolute left-0 top-1/2 -translate-y-1/2 text-muted-foreground/30 group-focus-within:text-primary transition-colors">
                     <Search size={16} />
                 </div>
                 <input 
-                    className="w-full bg-transparent border-b border-border py-2 pl-7 text-foreground placeholder:text-secondary/30 focus:outline-none focus:border-primary/50 transition-all text-sm font-medium"
+                    className="w-full bg-transparent border-b border-border py-2 pl-7 text-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:border-primary/50 transition-all text-sm font-medium"
                     placeholder="Search by title or notes..."
                     value={state.searchQuery}
                     onChange={(e) => actions.setSearchQuery(e.target.value)}
@@ -203,7 +203,7 @@ export const TaskDatabaseView: React.FC = () => {
               onToggle={() => toggleSection('overdue')}
               onStartAdding={() => {}} 
               onTaskScheduleToday={handleAddToFlow}
-              colorClass="text-red-400"
+              colorClass="text-destructive"
               {...sectionProps}
             />
            <TaskSection 


### PR DESCRIPTION
- Updated font to Inter and implemented shadCN Sky/Gray color palette in `globals.css` and `tailwind.config.ts`.
- Refactored `InsightsView.tsx` and `DashboardView.tsx` to use shadCN `Card` components and standard color utilities.
- Updated `AppLayout`, `Sidebar`, and `TaskRow` suite (including `TaskSection`, `Chip`, `TaskDisplay`) to align with the new theme and "small" radius requirement.
- Improved readability and contrast across the task list and navigation elements.
- Fixed type errors in `CalendarImportModal.tsx` to ensure successful build.