### PR TITLE
style: remodel task list to mail app style and fix sidebar

### DIFF
--- a/src/entities/task/ui/TaskRow.tsx
+++ b/src/entities/task/ui/TaskRow.tsx
@@ -101,90 +101,90 @@ const TaskRowComponent: React.FC<TaskRowProps> = ({
                 <ContextMenuTrigger>
                     <div
                         className={cn(
-                            "group flex items-center gap-3 py-2 px-3 border-b border-border last:border-0 transition-all duration-200 cursor-pointer hover:bg-muted/50",
+                            "group flex flex-col items-start gap-2 rounded-lg border p-3 text-left text-sm transition-all hover:bg-accent",
                             isBlocked && !isArchived && "opacity-50",
                             (isCompleted || isCompleting) && !isSelectionMode && "opacity-60",
                             highlight && "bg-primary/5",
                             isCompleting && !isSelectionMode && "opacity-0",
-                            isSelected && isSelectionMode && "bg-accent/50"
+                            isSelected && isSelectionMode && "bg-accent/50",
+                            "mx-1 my-0.5"
                         )}
                         onClick={handleRowClick}
                     >
-                        <div onClick={(e) => e.stopPropagation()} className="flex items-center">
-                            <Checkbox
-                                checked={isSelectionMode ? isSelected : (isCompleted || isCompleting)}
-                                onCheckedChange={handleCompleteChange}
-                                disabled={isBlocked && !isArchived && !isSelectionMode}
-                            />
-                        </div>
-
-                        <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                            <span className={cn(
-                                "text-sm font-medium truncate",
-                                (isCompleted || isCompleting) && "line-through text-muted-foreground"
-                            )}>
-                                {task.title}
-                            </span>
-
-                            <div className="flex items-center gap-1.5 flex-wrap">
-                                {/* Tag Badge */}
-                                <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal" style={{
-                                    borderColor: taskTag ? `${taskTag.color}44` : undefined,
-                                    color: taskTag?.color,
-                                    backgroundColor: taskTag ? `${taskTag.color}11` : undefined
-                                }}>
-                                    <Hash size={10} className="mr-1 shrink-0" />
-                                    {taskTag?.name || 'Inbox'}
-                                </Badge>
-
-                                {/* Date Badges */}
-                                {task.assignedDate && (
-                                    <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal text-primary border-primary/20 bg-primary/5">
-                                        <CalendarClock size={10} className="mr-1 shrink-0" />
-                                        {new Date(task.assignedDate).toLocaleDateString(undefined, {month:'short', day:'numeric'})}
-                                    </Badge>
-                                )}
-
-                                {task.dueDate && (
-                                    <Badge variant="outline" className={cn(
-                                        "text-[10px] px-2 py-0.5 whitespace-nowrap font-normal",
-                                        isOverdue ? "text-destructive border-destructive/20 bg-destructive/5 font-bold" : "text-muted-foreground border-border bg-muted/30"
+                        <div className="flex w-full flex-col gap-1">
+                            <div className="flex items-center">
+                                <div className="flex items-center gap-2">
+                                    <div onClick={(e) => e.stopPropagation()} className="flex items-center">
+                                        <Checkbox
+                                            checked={isSelectionMode ? isSelected : (isCompleted || isCompleting)}
+                                            onCheckedChange={handleCompleteChange}
+                                            disabled={isBlocked && !isArchived && !isSelectionMode}
+                                            className="h-4 w-4"
+                                        />
+                                    </div>
+                                    <div className={cn(
+                                        "font-semibold",
+                                        (isCompleted || isCompleting) && "line-through text-muted-foreground"
                                     )}>
-                                        <Calendar size={10} className="mr-1 shrink-0" />
-                                        {new Date(task.dueDate).toLocaleDateString(undefined, {month:'short', day:'numeric'})}
-                                    </Badge>
-                                )}
-
-                                {/* Timer / Duration Badge */}
-                                {isRunning && timeDisplay ? (
-                                    <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-mono text-primary border-primary/20 bg-primary/5 animate-pulse">
-                                        {timeDisplay}
-                                    </Badge>
-                                ) : (
-                                    <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal text-muted-foreground border-border bg-muted/30">
-                                        <Clock size={10} className="mr-1 shrink-0" />
-                                        {displayedDuration}m
-                                    </Badge>
-                                )}
-
-                                {/* Energy Badge */}
-                                <Badge variant="outline" className={cn(
-                                    "text-[10px] px-2 py-0.5 whitespace-nowrap font-normal",
-                                    task.energy === 'High' ? "text-orange-500 border-orange-500/20 bg-orange-500/5" :
-                                    task.energy === 'Low' ? "text-emerald-500 border-emerald-500/20 bg-emerald-500/5" :
-                                    "text-yellow-500 border-yellow-500/20 bg-yellow-500/5"
+                                        {task.title}
+                                    </div>
+                                </div>
+                                <div className={cn(
+                                    "ml-auto text-xs",
+                                    isSelected ? "text-foreground" : "text-muted-foreground"
                                 )}>
-                                    <Zap size={10} className="mr-1 shrink-0" />
-                                    {task.energy === 'Medium' ? 'Med' : task.energy}
-                                </Badge>
-
-                                {task.recurrence && <Repeat size={10} className="text-muted-foreground/50" />}
-                                {(task.blockedBy?.length || 0) > 0 && <GitBranch size={10} className="text-blue-500/50" />}
+                                    {task.dueDate ? new Date(task.dueDate).toLocaleDateString(undefined, {month:'short', day:'numeric'}) : (task.assignedDate ? new Date(task.assignedDate).toLocaleDateString(undefined, {month:'short', day:'numeric'}) : '')}
+                                </div>
                             </div>
                         </div>
+                        {task.notes && (
+                            <div className="line-clamp-2 text-xs text-muted-foreground">
+                                {task.notes}
+                            </div>
+                        )}
+                        <div className="flex items-center gap-1.5 mt-1">
+                            {/* Tag Badge */}
+                            <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal" style={{
+                                borderColor: taskTag ? `${taskTag.color}44` : undefined,
+                                color: taskTag?.color,
+                                backgroundColor: taskTag ? `${taskTag.color}11` : undefined
+                            }}>
+                                <Hash size={10} className="mr-1 shrink-0" />
+                                {taskTag?.name || 'Inbox'}
+                            </Badge>
 
-                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <MoreHorizontal size={14} className="text-muted-foreground" />
+                            {/* Date Badges */}
+                            {task.assignedDate && (
+                                <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal text-primary border-primary/20 bg-primary/5">
+                                    <CalendarClock size={10} className="mr-1 shrink-0" />
+                                    {new Date(task.assignedDate).toLocaleDateString(undefined, {month:'short', day:'numeric'})}
+                                </Badge>
+                            )}
+
+                            {/* Timer / Duration Badge */}
+                            {isRunning && timeDisplay ? (
+                                <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-mono text-primary border-primary/20 bg-primary/5 animate-pulse">
+                                    {timeDisplay}
+                                </Badge>
+                            ) : (
+                                <Badge variant="outline" className="text-[10px] px-2 py-0.5 whitespace-nowrap font-normal text-muted-foreground border-border bg-muted/30">
+                                    <Clock size={10} className="mr-1 shrink-0" />
+                                    {displayedDuration}m
+                                </Badge>
+                            )}
+
+                            {/* Energy Badge */}
+                            <Badge variant="outline" className={cn(
+                                "text-[10px] px-2 py-0.5 whitespace-nowrap font-normal",
+                                task.energy === 'High' ? "text-orange-500 border-orange-500/20 bg-orange-500/5" :
+                                task.energy === 'Low' ? "text-emerald-500 border-emerald-500/20 bg-emerald-500/5" :
+                                "text-yellow-500 border-yellow-500/20 bg-yellow-500/5"
+                            )}>
+                                <Zap size={10} className="mr-1 shrink-0" />
+                                {task.energy === 'Medium' ? 'Med' : task.energy}
+                            </Badge>
+
+                            {task.recurrence && <Repeat size={10} className="text-muted-foreground/50" />}
                         </div>
                     </div>
                 </ContextMenuTrigger>

--- a/src/entities/task/ui/TaskSection.tsx
+++ b/src/entities/task/ui/TaskSection.tsx
@@ -68,26 +68,26 @@ export const TaskSection: React.FC<TaskSectionProps> = ({
       collapsible
       value={isExpanded ? sectionKey : ""}
       onValueChange={(val) => onToggle()}
-      className="mb-2"
+      className="mb-4"
     >
       <AccordionItem value={sectionKey} className="border-none">
         <AccordionTrigger className={cn(
-          "hover:no-underline py-2 px-3 hover:bg-muted/30 rounded-sm transition-colors",
+          "hover:no-underline py-2 px-3 hover:bg-muted/10 rounded-lg transition-colors",
           (sectionKey === 'completed' || sectionKey === 'archived') && "opacity-60"
         )}>
           <div className="flex-1 flex justify-between items-center pr-4">
-            <h2 className={cn("text-xs font-semibold tracking-tight", colorClass)}>
+            <h2 className={cn("text-[11px] font-bold uppercase tracking-widest opacity-40", colorClass)}>
               {title}
             </h2>
-            <Badge variant="secondary" className="text-[10px] h-4.5 px-1.5 py-0 font-medium tabular-nums">
+            <Badge variant="secondary" className="text-[10px] px-2 py-0 font-bold tabular-nums bg-muted/50">
               {displayCount}
             </Badge>
           </div>
         </AccordionTrigger>
-        <AccordionContent className="pt-1 pb-2">
+        <AccordionContent className="pt-2 pb-2">
           <div className={cn(
-            "space-y-px",
-            sectionKey === 'overdue' && "border-l-2 border-destructive/20 ml-1"
+            "space-y-2 px-1",
+            sectionKey === 'overdue' && "border-l border-destructive/20 ml-1"
           )}>
             {tasks.map((task) => (
               <TaskRow

--- a/src/views/TaskDatabaseView.tsx
+++ b/src/views/TaskDatabaseView.tsx
@@ -164,16 +164,18 @@ export const TaskDatabaseView: React.FC = () => {
        />
 
        <Page.Content>
-            <div className="mb-6 group relative">
-                <div className="absolute left-0 top-1/2 -translate-y-1/2 text-muted-foreground/30 group-focus-within:text-primary transition-colors">
-                    <Search size={16} />
+            <div className="bg-background/95 p-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+                <form>
+                <div className="relative">
+                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input
+                        placeholder="Search tasks..."
+                        className="pl-8"
+                        value={state.searchQuery}
+                        onChange={(e) => actions.setSearchQuery(e.target.value)}
+                    />
                 </div>
-                <input 
-                    className="w-full bg-transparent border-b border-border py-2 pl-7 text-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:border-primary/50 transition-all text-sm font-medium"
-                    placeholder="Search by title or notes..."
-                    value={state.searchQuery}
-                    onChange={(e) => actions.setSearchQuery(e.target.value)}
-                />
+                </form>
             </div>
            <TaskSection
               sectionKey="overdue"


### PR DESCRIPTION
- Remodel TaskRow to match Shadcn Mail app list item (multi-line, card-style)
- Fix Sidebar and TagTree to match Shadcn Sidebar-11 style (New York)
- Integrate real-time NLP parsing in CreateTaskSheetContent
- Fix broken badges, section headers, and context menu transparency
- Add sidebar tokens and update globals.css/tailwind.config.ts